### PR TITLE
Add support for parsing filter specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ As examples of things I would like to be able to do:
 Where `barney` is an example customer.
 
 ```
-ssh $(box barney:live:kermit.green)  # ssh into the barney live  box named kermit.green box
-ssh $(box barney:live)               # ssh into any available barney live box
+box ssh barney:live:kermit.green  # ssh into the barney live  box named kermit.green box
+box ssh barney:live               # ssh into any available barney live box
 ```
 
 

--- a/box.cabal
+++ b/box.cabal
@@ -16,7 +16,6 @@ library
                      , attoparsec                      == 0.12.*
                      , directory                       == 1.2.*
                      , either                          == 4.3.*
-                     , Glob                            == 0.7.*
                      , mismi-s3
                      , p
                      , random-shuffle                  == 0.0.4
@@ -41,6 +40,7 @@ executable             box
     ghc-options:      -Wall -threaded -O2
     main-is:           main/box.hs
     build-depends:     base
+                     , attoparsec                      == 0.12.*
                      , box
                      , either
                      , mismi-s3

--- a/main/box.hs
+++ b/main/box.hs
@@ -74,7 +74,7 @@ boxIP _ q hostType boxes = do
 
 boxSSH :: RunType -> Query -> [SSHArg] -> [Box] -> EitherT BoxCommandError IO ()
 boxSSH runType qTarget args boxes = do
-  let qGateway = Query MatchAll MatchAll MatchAll (Match (Flavour "gateway"))
+  let qGateway = Query ExactAll (Exact (Flavour "gateway")) InfixAll
 
   t <- randomBoxOfQuery qTarget  boxes
   g <- randomBoxOfQuery qGateway boxes
@@ -178,47 +178,10 @@ hostTypeP =
     <> help "Display the external ip address rather than the internal one (which is the default)."
 
 queryP :: Parser Query
-queryP = Query
-  <$> matchParser instanceIdP
-  <*> matchParser nameP
-  <*> matchParser clientP
-  <*> matchParser flavourP
-
-nameP :: Parser Name
-nameP =
-  fmap Name . option textRead $
-       long "name"
-    <> short 'n'
-    <> metavar "NAME_FILTER"
-    <> help "Filter by the instance name"
-
-instanceIdP :: Parser InstanceId
-instanceIdP =
-  fmap InstanceId . option textRead $
-       long "instance"
-    <> short 'i'
-    <> metavar "INSTANCE_FILTER"
-    <> help "Filter by the instance ID"
-
-clientP :: Parser Client
-clientP =
-  fmap Client . option textRead $
-       long "client"
-    <> short 'c'
-    <> metavar "CLIENT_FILTER"
-    <> help "Filter by the instance client"
-
-flavourP :: Parser Flavour
-flavourP =
-  fmap Flavour . option textRead $
-       long "flavour"
-    <> short 'f'
-    <> metavar "FLAVOUR_FILTER"
-    <> help "Filter by the instance flavour"
-
-matchParser :: Parser a -> Parser (Match a)
-matchParser =
-  fmap (maybe MatchAll Match) . optional
+queryP =
+  argument (pOption queryParser) $
+       metavar "FILTER"
+    <> help "Filter using the following syntax: CLIENT[:FLAVOUR[:NAME]]"
 
 sshArgP :: Parser SSHArg
 sshArgP =

--- a/test/Test/Box/Data.hs
+++ b/test/Test/Box/Data.hs
@@ -15,8 +15,10 @@ import           Test.Box.Arbitrary ()
 import           Test.QuickCheck
 
 
-prop_parse_tripping = tripping boxToText boxFromText
-prop_parse_all_tripping = tripping boxesToText boxesFromText
+prop_parse_query_tripping = tripping queryRender queryFromText
+
+prop_parse_box_tripping   = tripping boxToText boxFromText
+prop_parse_boxes_tripping = tripping boxesToText boxesFromText
 
 prop_select_host b bs = testIO . fmap isJust . selectRandomBox $ b : bs
 prop_select_host_none = testIO . fmap isNothing . selectRandomBox $ []

--- a/test/cli/basic/run
+++ b/test/cli/basic/run
@@ -10,24 +10,24 @@ $BOX -v
 
 $BOX --version
 
-if $BOX ip --name "mincom"; then exit 1; fi
+if $BOX ip ::nomatches; then exit 1; fi
 if $BOX; then exit 1; fi
-$BOX ip --name "mincom.*"
-$BOX ip --instance "i-a057m17c"
-$BOX ip --client "acme"
-$BOX ip --flavour "lab"
-$BOX ip --external --flavour "lab"
-$BOX ip --external --instance "i-a057m17c"
-$BOX ip --name "mincom.*" --instance "i-932db44b"
-$BOX ip --name "mincom.*" --instance "i-932db44b" --client "mincom"
-$BOX ip --name "mincom.*" --instance "i-932db44b" --client "mincom" --flavour "land"
-if $BOX ip --name "acme.*" --instance "i-932db44b" --client "mincom" --flavour "land"; then exit 1; fi
-if $BOX ip --name "mincom.*" --instance "i-932db44c" --client "mincom" --flavour "land"; then exit 1; fi
-if $BOX ip --name "mincom.*" --instance "i-932db44b" --client "acme" --flavour "land"; then exit 1; fi
-if $BOX ip --name "mincom.*" --instance "i-932db44b" --client "mincom" --flavour "hub"; then exit 1; fi
+$BOX ip mincom
+$BOX ip acme
+$BOX ip :lab
+$BOX ip --external :lab
+$BOX ip mincom:land
+$BOX ip mincom:land:zoot
+$BOX ip mincom:land:zoot.golden
+$BOX ip mincom:land:golden
+$BOX ip ::zoot.golden
+if $BOX ip acme:land; then exit 1; fi
+if $BOX ip mincom:land:brown; then exit 1; fi
+if $BOX ip mincom:land:kermit; then exit 1; fi
+if $BOX ip mincom:hub; then exit 1; fi
 
 EXPECT='["ssh","-o","ProxyCommand=ssh -i '$BOX_IDENTITY' '$BOX_USER'@54.1.1.6 nc %h %p 2>/dev/null","-o","HostKeyAlias=box.acme.lab.kermit.brown.717.jump","'$BOX_USER'@192.31.14.3"]'
-ACTUAL=$($BOX --dry-run ssh --client "acme" --flavour "lab")
+ACTUAL=$($BOX --dry-run ssh acme:lab)
 
 if [ "$EXPECT" != "$ACTUAL" ]; then
   echo "expected: $EXPECT"


### PR DESCRIPTION
Filter specs look like:

  CLIENT
  CLIENT[:FLAVOUR]
  CLIENT[:FLAVOUR[:NAME]]

At least one of client, flavour and name must be specified.
