### PR TITLE
Don't use `getLoginName`, because `getlogin(3)` is terrible

### DIFF
--- a/main/box.hs
+++ b/main/box.hs
@@ -193,7 +193,7 @@ storeEnv =
 
 userEnv :: IO Text
 userEnv =
-  T.pack <$> (maybe getLoginName return =<< lookupEnv "BOX_USER")
+  T.pack <$> (maybe getEffectiveUserName return =<< lookupEnv "BOX_USER")
 
 identityEnv :: IO Text
 identityEnv = do


### PR DESCRIPTION
Use `getEffectiveUserName === getpwuid(geteuid())` instead.

From the man page:

> Unfortunately, it is often rather easy to fool getlogin(). Sometimes it
> does not work at all, because some program messed up the utmp file.
> Often, it gives only the first 8 characters of the login name. The user
> currently logged in on the controlling terminal of our program need not
> be the user who started it.

It's also in practice rather nonportable.

/cc @jystic 

(This is making `box ssh` crash on startup for me.)
