### PR TITLE
Add -e flag to switch environments

### DIFF
--- a/src/Box/Data.hs
+++ b/src/Box/Data.hs
@@ -16,6 +16,7 @@ module Box.Data (
   , Flavour (..)
   , GatewayType (..)
   , BoxError (..)
+  , Environment (..)
   , queryHasMatch
   , queryFromText
   , queryParser
@@ -112,6 +113,11 @@ data GatewayType =
     Gateway
     -- | Uses pubkey authentication + TOTP.
   | GatewaySecure
+  deriving (Eq, Show)
+
+data Environment =
+    SomeEnv Text
+  | DefaultEnv
   deriving (Eq, Show)
 
 ------------------------------------------------------------------------

--- a/src/Box/Store.hs
+++ b/src/Box/Store.hs
@@ -4,7 +4,8 @@ module Box.Store (
     module Mismi
   , readBoxes
   , writeBoxes
-  , boxStoreAddress
+  , listEnvironments
+  , defaultBoxStore
   ) where
 
 import           Box.Data
@@ -12,29 +13,53 @@ import           Box.Data
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Either
 
+import           Data.Text as T
 import           Data.Text.IO as T
 
 import           Mismi as Mismi hiding (InstanceId, matchAll, timeout, parser)
-import           Mismi.S3 as Mismi hiding (InstanceId, matchAll, timeout, parser)
+import           Mismi.S3 as Mismi hiding (InstanceId, key, matchAll, timeout, parser, (</>))
 
 import           P
 
 import           System.Directory
+import           System.FilePath as FP
 
+readBoxes :: BoxStore -> Environment -> AWS (Either BoxError [Box])
+readBoxes bxs env = case boxStoreWithEnv bxs env of
+  bs@(BoxStoreLocal fp) -> liftIO . runEitherT $ do
+    t <- EitherT $ ifM (doesFileExist fp) (fmap Right $ T.readFile fp) (pure . Left $ BoxNotFound bs)
+    hoistEither . first BoxParseError $ boxesFromText t
+  bs@(BoxStoreS3 a) ->
+    (=<<) (first BoxParseError . boxesFromText) . maybeToRight (BoxNotFound bs) <$> Mismi.read a
 
-readBoxes :: BoxStore -> AWS (Either BoxError [Box])
-readBoxes bs@(BoxStoreLocal fp) = liftIO . runEitherT $ do
-   t <- EitherT $ ifM (doesFileExist fp) (fmap Right $ T.readFile fp) (pure . Left $ BoxNotFound bs)
-   hoistEither . first BoxParseError $ boxesFromText t
-readBoxes bs@(BoxStoreS3 a) =
-  (=<<) (first BoxParseError . boxesFromText) . maybeToRight (BoxNotFound bs) <$> Mismi.read a
+writeBoxes :: [Box] -> BoxStore -> Environment -> AWS ()
+writeBoxes bs bxs env = case boxStoreWithEnv bxs env of
+  BoxStoreLocal lf -> liftIO $
+    ifM (doesFileExist lf) (fail $ "File already exists " <> lf) (T.writeFile lf . boxesToText $ bs)
+  BoxStoreS3 a ->
+    void . Mismi.writeWithMode Fail a . boxesToText $ bs
 
-writeBoxes :: [Box] -> BoxStore -> AWS ()
-writeBoxes bs (BoxStoreLocal lf) = liftIO $
-  ifM (doesFileExist lf) (fail $ "File already exists " <> lf) (T.writeFile lf . boxesToText $ bs)
-writeBoxes bs (BoxStoreS3 a) =
-  void . Mismi.writeWithMode Fail a . boxesToText $ bs
+listEnvironments :: BoxStore -> AWS [Text]
+listEnvironments bs = envNames bs
+  where
+    envNames (BoxStoreLocal fp) = do
+      paths <- liftIO $ getDirectoryContents (takeDirectory fp)
+      return [ noSuffix p | p <- paths, validEnv p ]
+    envNames (BoxStoreS3 (Address b key)) = do
+      paths <- Mismi.list (Address b (dirname key))
+      return [ noSuffix x | p <- paths, let x = unpackKey p, validEnv x]
+    noSuffix = T.pack . dropExtension . takeFileName
+    validEnv = (== ".v2") . takeExtension
+    unpackKey (Address _ (Key k)) = T.unpack k
 
-boxStoreAddress :: Address
-boxStoreAddress =
-  Address (Bucket "ambiata-dispensary") (Key "box/v2")
+defaultBoxStore :: BoxStore
+defaultBoxStore =
+  BoxStoreS3 (Address (Bucket "ambiata-dispensary") (Key "box/v2"))
+
+-- Filepath munging for alt environments
+boxStoreWithEnv :: BoxStore -> Environment -> BoxStore
+boxStoreWithEnv bs DefaultEnv = bs
+boxStoreWithEnv (BoxStoreS3 (Address b (Key k))) (SomeEnv e) =
+  BoxStoreS3 (Address b (Key . T.pack $ dropFileName (T.unpack k) </> T.unpack e <.> ".v2"))
+boxStoreWithEnv (BoxStoreLocal lf) (SomeEnv e) =
+  BoxStoreLocal (dropFileName lf </> T.unpack e <.> ".v2")

--- a/test/Test/IO/Box/Store.hs
+++ b/test/Test/IO/Box/Store.hs
@@ -22,8 +22,8 @@ prop_readwrite_local bs = withLocalAWS $ \path _ -> do
 
 writeReadBoxes :: [Box] -> BoxStore -> AWS Property
 writeReadBoxes bs f = do
-  writeBoxes bs f
-  bs' <- readBoxes f
+  writeBoxes bs f DefaultEnv
+  bs' <- readBoxes f DefaultEnv
   pure $ bs' === Right bs
 
 

--- a/test/cli/basic/altenv.v2
+++ b/test/cli/basic/altenv.v2
@@ -1,0 +1,8 @@
+i-c1c1127j 172.131.228.17 152.44.142.182 asg.gatewaysecure.helium.gws ambiata gatewayinsecure
+i-9691127j 172.131.29.9 152.65.153.178 asg.gatewaysecure.helium.bingo ambiata gatewaysecure
+i-c841127j 172.131.22.14 152.65.3.138 asg.totp.helium.blargho ambiata totp
+i-84d1127j 172.131.116.23 152.65.171.235 asg.totp.helium.scrub ambiata totp
+i-0161127j 172.131.113.24 152.65.159.245 ambiata.totpadmin.kermit.pink.171 ambiata totpadmin
+i-aa91127j 172.131.122.7 152.65.150.142 asg.totp.helium.burrito ambiata totp
+i-8fe1127j 172.131.124.15 152.165.47.250 asg.gatewaysecure.helium.badtest ambiata gatewayinsecure
+i-fe6988ed 192.31.15.2 54.22.33.6 ambiata.gateway.mapple.gary.7 ambiata gateway

--- a/test/cli/basic/run
+++ b/test/cli/basic/run
@@ -74,3 +74,67 @@ EOF
 )
 ACTUAL=$($BOX --zsh-commands)
 check "$EXPECT" "$ACTUAL"
+
+# Test -e flag is parsed correctly
+echo "Testing -e flag parses correctly..."
+EXPECT=$($BOX --help 2>&1)
+ACTUAL=$($BOX -e altenv --help 2>&1)
+check "$EXPECT" "$ACTUAL"
+
+EXPECT=$($BOX --help 2>&1)
+ACTUAL=$($BOX --environment customenv --help 2>&1)
+check "$EXPECT" "$ACTUAL"
+
+EXPECT=$($BOX --environment altenv ls)
+ACTUAL=$($BOX -e altenv ls)
+check "$EXPECT" "$ACTUAL"
+
+ACTUAL=$($BOX ls -e altenv)
+check "$EXPECT" "$ACTUAL"
+
+# Test that bad env args don't run
+echo "Testing invalid environment arg..."
+EXPECT="Could not find the box file located at"
+ACTUAL=$($BOX -e badenv ls 2>&1 | cut -d':' -f1)
+check "$EXPECT" "$ACTUAL"
+
+ACTUAL=$($BOX ls --environment badenv 2>&1 | cut -d':' -f1)
+check "$EXPECT" "$ACTUAL"
+
+# Test we get the correct set of values from altenv
+echo "Testing with alt environment..."
+
+CMD="$BOX -e altenv ip ambiata:totpadmin"
+EXPECT="172.131.113.24"
+echo $CMD
+ACTUAL=$($CMD)
+check "$EXPECT" "$ACTUAL"
+
+CMD="$BOX -e altenv ip ambiata:totp:asg.totp.helium.blargho"
+EXPECT="172.131.22.14"
+echo $CMD
+ACTUAL=$($CMD)
+check "$EXPECT" "$ACTUAL"
+
+# Test ssh and ssh -s finds correct params from correct env
+CMD="$BOX -e altenv --dry-run ssh ambiata:totp:asg.totp.helium.blargho"
+EXPECT='["ssh","-o","ProxyCommand=ssh -i '$BOX_IDENTITY' -o HostKeyAlias=box.ambiata.gateway.mapple.gary.7.i-fe6988ed.jump '$BOX_USER'@54.22.33.6 nc %h %p 2>/dev/null","-o","HostKeyAlias=box.asg.totp.helium.blargho.i-c841127j.jump","'$BOX_USER'@172.131.22.14"]'
+echo $CMD
+ACTUAL=$($CMD)
+check "$EXPECT" "$ACTUAL"
+
+CMD="$BOX -e altenv --dry-run ssh -s ambiata:totp:asg.totp.helium.blargho"
+EXPECT='["ssh","-o","ProxyCommand=ssh -i '$BOX_IDENTITY' -o HostKeyAlias=box.asg.gatewaysecure.helium.bingo.i-9691127j.jump '$BOX_USER'@152.65.153.178 nc %h %p 2>/dev/null","-o","HostKeyAlias=box.asg.totp.helium.blargho.i-c841127j.jump","'$BOX_USER'@172.131.22.14"]'
+echo $CMD
+ACTUAL=$($CMD)
+check "$EXPECT" "$ACTUAL"
+
+# Test explicit v1 (set via env) still works
+echo "Testing v1..."
+export BOX_STORE=test/cli/basic/v1
+
+CMD="$BOX ip ambiata:farm"
+EXPECT="10.1.10.24"
+echo $CMD
+ACTUAL=$($CMD)
+check "$EXPECT" "$ACTUAL"

--- a/test/cli/basic/v1
+++ b/test/cli/basic/v1
@@ -1,0 +1,7 @@
+i-9bfabcde 10.1.17.16 152.165.59.27 asg.gateway.ci.giblet ambiata gateway
+i-9daabcde 10.1.17.67 152.165.67.3 ambiata.cimaster.omar.yellow.718 ambiata cimaster
+i-0eaabcde 10.1.111.18 152.164.230.12 asg.hub.ci.abcde ambiata hub
+i-514abcde 10.1.129.60 152.165.3.1 asg.cimaster.ci.blech ambiata cimaster
+i-95aabcde 10.1.130.21 152.164.242.6 asg.gateway.ci.kyle ambiata gateway
+i-00fabcde 10.1.10.24 152.164.26.25 asg.hook.ci.ping ambiata farm
+i-736abcde 10.1.124.16 154.153.178.13 asg.bot.ci.garbo ambiata bot


### PR DESCRIPTION
- Each environment gets its own cache file in $HOME/.ambiata/box
- BOX_STORE env variable still takes priority.
- Uses convention discussed in #30 (s3://ambiata-dispensary/box/<environment>.v2)
- Completion works via awful hack (inspecting argv inside an arg parser)

Add parser test for -e flag

Hard to test actual flag function without changing behaviour of BOX_STORE.
