### PR TITLE
Print a more specific error message if box can't find a gateway

### DIFF
--- a/box.cabal
+++ b/box.cabal
@@ -49,6 +49,7 @@ executable             box
                      , ambiata-mismi-s3
                      , ambiata-p
                      , ambiata-x-optparse
+                     , ambiata-x-either
                      , attoparsec                      == 0.12.*
                      , boxes                           == 0.1.*
                      , directory                       == 1.2.*


### PR DESCRIPTION
/cc @jystic 

```
(aws)∃ box ls
[ ... ]
ambiata totpadmin                                                kermit.pink.171  172.31.13.242  52.65.59.245   i-c9b0d016
(aws)∃ box ssh :totpadmin
No matching boxes found
```

Confused me for a minute.
