### PR TITLE
Direct connections now use RSA host key from power V3 file

### DIFF
--- a/test/cli/basic/run
+++ b/test/cli/basic/run
@@ -5,7 +5,7 @@ BOX=${1:-./dist/build/box/box}
 export BOX_STORE=test/cli/basic/v3
 export BOX_USER=pwadler
 export BOX_IDENTITY=~/.ssh/endofunctor_rsa
-export BOX_KNOWN_HOSTS=~/.ssh/box_known_hosts
+export BOX_KNOWN_HOSTS=/tmp/box_test_known_hosts
 export BOX_ANSI_ESCAPES=0
 
 $BOX -v
@@ -133,3 +133,5 @@ EXPECT='["ssh","-o","ProxyCommand=ssh -i '$BOX_IDENTITY' -o HostKeyAlias=box.asg
 echo $CMD
 ACTUAL=$($CMD)
 check "$EXPECT" "$ACTUAL"
+
+rm -f $BOX_KNOWN_HOSTS


### PR DESCRIPTION
When invoking SSH for a direct connection box now grabs the RSA host
key from the Box struct and writes it to `~/.ssh/box_known_hosts`
before invoking SSH with `-o UserKnownHostsFile=~/.ssh/box_known_hosts`.

There is potential for a race conditon on that file if the user tries
to run two instances of box simultaneously. This is unlikely, but if
it becomes an issue we can investigate file locking for that file.

The `-o UserKnownHostsFile=...` option is supported by the oldest
SSH client version I can find in the office (OpenSSH_6.2p2) so I
suspect it should be fine everywhere.

/cc @olorin @jystic @nhibberd : Interested in your opinion on the potential for a race condition. Worth fixing?
