### PR TITLE
Use `BOX_IDENTITY` when connecting directly to gateway

### DIFF
--- a/main/box.hs
+++ b/main/box.hs
@@ -143,11 +143,11 @@ boxSSH runType gwType qTarget args boxes = do
           <> userHost user targetHost -- Connect to target
           <> args                     -- Pass on remaining args to SSH
     ---
-    goDirect target user _ident = do
+    goDirect target user ident = do
       let targetHost = unHost (selectHost ExternalHost target)
       tmpKnownHosts <- liftIO $ knownHostsFile target Nothing
       go runType (boxNiceName target) $
-        [ "-o", "UserKnownHostsFile=" <> tmpKnownHosts ]
+        [ "-i", ident, "-o", "UserKnownHostsFile=" <> tmpKnownHosts ]
         <> userHost user targetHost <> args
     ---
     go runtype boxname args' = case runtype of

--- a/test/cli/basic/run
+++ b/test/cli/basic/run
@@ -65,7 +65,7 @@ EXPECT='["ssh","-o","ProxyCommand=ssh -i '$BOX_IDENTITY' -o UserKnownHostsFile=/
 ACTUAL=$($BOX --dry-run ssh -s acme:lab)
 check "$EXPECT" "$ACTUAL"
 
-EXPECT='["ssh","-o","UserKnownHostsFile='$BOX_KNOWN_HOSTS'","'$BOX_USER'@54.1.1.6"]'
+EXPECT='["ssh","-i","~/.ssh/endofunctor_rsa","-o","UserKnownHostsFile='$BOX_KNOWN_HOSTS'","'$BOX_USER'@54.1.1.6"]'
 ACTUAL=$($BOX --dry-run ssh :gateway:)
 check "$EXPECT" "$ACTUAL"
 


### PR DESCRIPTION
Now uses `BOX_IDENTITY` in the same way as it would when going via
the gateway.

Closes: https://github.com/ambiata/box/issues/59

/cc @nhibberd @jystic @olorin 
