### PR TITLE
Fix parameters for autossh

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@ box ls vapour
 box ls :live
 box ls :dev
 
-# rsync source.txt in the current working directory to a file remote.txt 
+# rsync source.txt in the current working directory to a file remote.txt
 # in your home directory on vapour:dev:kermit
 box rsync vapour:dev:kermit -- -aH source.txt :remote.txt
 
-# rsync source.txt in the current working directory to an absolute file 
+# rsync source.txt in the current working directory to an absolute file
 # path /tmp/remote.txt in your home directory on vapour:dev:kermit
 box rsync vapour:dev:kermit -- -aH source.txt :/tmp/remote.txt
 
-# rsync remote.txt in your remote home directory to a file local.txt 
+# rsync remote.txt in your remote home directory to a file local.txt
 box rsync vapour:dev:kermit -- -aH :remote.txt local.txt
 
 # rsync an absolute directory in to a local dir
 box rsync vapour:dev:kermit -- -aH :/mnt/me/plots plots
 
-# NOTE WELL: -aH is the 'just works' options for rsync, and should be 
+# NOTE WELL: -aH is the 'just works' options for rsync, and should be
 #            all you need for almost all cases.
 ```
 
@@ -112,7 +112,7 @@ box ssh vapour:dev:fozzie -- -L 8787:localhost:8787
 box ssh [-s|--secure] [filter]
 ```
 
-Note: The flag needs to come after the `ssh` parameter. Order matters. 
+Note: The flag needs to come after the `ssh` parameter. Order matters.
 
 [More information on SSH 2-Factor-Authentication](https://github.com/ambiata/architecture/blob/master/operations/ssh-2fa.md)
 

--- a/test/cli/basic/run
+++ b/test/cli/basic/run
@@ -65,8 +65,18 @@ EXPECT='["ssh","-o","ProxyCommand=ssh -i '$BOX_IDENTITY' -o UserKnownHostsFile=/
 ACTUAL=$($BOX --dry-run ssh -s acme:lab)
 check "$EXPECT" "$ACTUAL"
 
-EXPECT='["autossh","-M 0 "," -o \"ServerAliveInterval 30\""," -o \"ServerAliveCountMax 3\"","-o","ProxyCommand=ssh -i '$BOX_IDENTITY' -o UserKnownHostsFile=/tmp/box_test_known_hosts '$BOX_USER'@54.1.1.8 nc %h %p 2>/dev/null","-o","UserKnownHostsFile=/tmp/box_test_known_hosts","'$BOX_USER'@192.31.14.3"]'
+EXPECT='["autossh","-M","0","-o","ServerAliveInterval 30","-o","ServerAliveCountMax 3","-o","ProxyCommand=ssh -i '$BOX_IDENTITY' -o UserKnownHostsFile=/tmp/box_test_known_hosts '$BOX_USER'@54.1.1.8 nc %h %p 2>/dev/null","-o","UserKnownHostsFile=/tmp/box_test_known_hosts","'$BOX_USER'@192.31.14.3"]'
 ACTUAL=$($BOX --dry-run ssh --auto -s acme:lab)
+check "$EXPECT" "$ACTUAL"
+
+# running box ssh in the background - pass -f as an ssh arg
+EXPECT='["ssh","-o","ProxyCommand=ssh -i '$BOX_IDENTITY' -o UserKnownHostsFile=/tmp/box_test_known_hosts '$BOX_USER'@54.1.1.8 nc %h %p 2>/dev/null","-o","UserKnownHostsFile=/tmp/box_test_known_hosts","'$BOX_USER'@192.31.14.3","-f"]'
+ACTUAL=$($BOX --dry-run ssh -b -s acme:lab)
+check "$EXPECT" "$ACTUAL"
+
+# with --auto, pass -f to autossh instead
+EXPECT='["autossh","-f","-M","0","-o","ServerAliveInterval 30","-o","ServerAliveCountMax 3","-o","ProxyCommand=ssh -i '$BOX_IDENTITY' -o UserKnownHostsFile=/tmp/box_test_known_hosts '$BOX_USER'@54.1.1.8 nc %h %p 2>/dev/null","-o","UserKnownHostsFile=/tmp/box_test_known_hosts","'$BOX_USER'@192.31.14.3"]'
+ACTUAL=$($BOX --dry-run ssh --auto -b -s acme:lab)
 check "$EXPECT" "$ACTUAL"
 
 EXPECT='["ssh","-i","'$BOX_IDENTITY'","-o","UserKnownHostsFile='$BOX_KNOWN_HOSTS'","'$BOX_USER'@54.1.1.6"]'


### PR DESCRIPTION
Prepping to get the binary for `box` into `appshop` resulted in the rather unpleasant discovery that the params need further fixing for this to actually work (thanks @charleso 😊)

 While I was at it I realised that if you want `autossh` to work in the background you have to pass it `-f` (sending that as an `SSH arg` does not work). So, have made that the default behaviour - i.e. it will always run with `-f` and thus, always in the background.

👀 again please @olorin @charleso? Thanks!
